### PR TITLE
Change the way we handle images

### DIFF
--- a/server/controllers/api/images/index.ts
+++ b/server/controllers/api/images/index.ts
@@ -47,7 +47,8 @@ async function listImages (req: express.Request, res: express.Response) {
   });
   var imagesUrl = images.map((i) => {
     return {
-      url: ImageModel.getImageStaticUrl(parse(i.filename).name, i.filename),
+      url: ImageModel.getImageStaticUrl(parse(i.filename).name, i.originalname),
+      regular: ImageModel.getImageStaticUrl(parse(i.filename).name, i.filename),
       thumbnail: ImageModel.getImageStaticUrl(parse(i.filename).name, i.thumbnailname)
     }
   });


### PR DESCRIPTION
Change the way we handle the image upload:

- Add a check for the maximum image size: if width * height > 16*1000*1000, then we return an error
- We now have 3 versions of the image:  original, regular (1280px) and thumbnail (256px)
- Depending on the original image size, we will create smaller versions of the original image if needed

Examples:

Image sent is 100px:
  original -> 100px
  regular -> 100px
  thumbnail -> 100px

Image sent is 500px:
  original -> 500px
  regular -> 500px
  thumbnail -> 256px

Image sent is 2000px:
  original -> 2000px
  regular -> 1280px
  thumbnail -> 256px

Image sent is 5000px * 5000px:
  => throw an error (image too big)